### PR TITLE
Fix markdown link type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Manually-configured authorization can be achieved using the
 [`golang.org/x/oauth2`](https://godoc.org/golang.org/x/oauth2) package to
 create an `oauth2.TokenSource`. This token source can be passed to the `NewClient`
 function for the relevant API using a 
-[`cloud.WithTokenSource`][https://godoc.org/google.golang.org/cloud#WithTokenSource]
+[`cloud.WithTokenSource`](https://godoc.org/google.golang.org/cloud#WithTokenSource)
 option.
 
 ## Google Cloud Datastore


### PR DESCRIPTION
Someone accidentally messed up a link's markdown.