### PR TITLE
datastore: update maxIndexedProperties from 5000 to 20000

### DIFF
--- a/datastore/prop.go
+++ b/datastore/prop.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Entities with more than this many indexed properties will not be saved.
-const maxIndexedProperties = 5000
+const maxIndexedProperties = 20000
 
 // []byte fields more than 1 megabyte long will not be loaded or saved.
 const maxBlobLen = 1 << 20


### PR DESCRIPTION
The datastore package is currently enforcing a limit of 5,000 indexed properties for entities. Unless Cloud Datastore differs from the App Engine Datastore in some subtle way, that limit was increased to [20,000 indexed properties](https://cloud.google.com/appengine/docs/python/datastore/entities#Python_Properties_and_value_types) several years ago.

When I brought up the issue on the appengine-go mailing list last year, @gmlewis kindly made [this commit](https://github.com/golang/appengine/commit/3783dc1d1c65a5c1f47a9ac111d6465ff5486459) on the [golang/appengine](https://github.com/golang/appengine) repo. It would be great if the change could be applied on this repo too. Cheers! 🍻